### PR TITLE
Update to upstream chart 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use different ports to avoid collision with ebs controller using ports 9909 and 9809
+- Updated chart to upstream 2.2.6
+- Improve tolerations to deploy in all worker nodes
+- Remove root security context from pods
+
 ## [0.4.0] - 2022-04-28
 
 ### Changed

--- a/helm/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/helm/aws-efs-csi-driver/templates/_helpers.tpl
@@ -10,9 +10,48 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "aws-efs-csi-driver.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-efs-csi-driver.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-efs-csi-driver.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Common labels
 */}}
+{{- define "aws-efs-csi-driver.labels" -}}
+app.kubernetes.io/name: {{ include "aws-efs-csi-driver.name" . }}
+helm.sh/chart: {{ include "aws-efs-csi-driver.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{- define "labels.common" -}}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/name: {{ .Values.name | quote }}

--- a/helm/aws-efs-csi-driver/templates/clusterrole-efs-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrole-efs-controller.yaml
@@ -29,6 +29,6 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
-    resourceNames: [{{ .Values.controller.serviceAccount.name }}]
+    resourceNames: ["efs-csi-controller"]
     verbs: ["use"]
 {{- end }}

--- a/helm/aws-efs-csi-driver/templates/clusterrole-efs-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrole-efs-controller.yaml
@@ -29,6 +29,6 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
-    resourceNames: ["efs-csi-controller"]
+    resourceNames: [{{ .Values.controller.serviceAccount.name }}]
     verbs: ["use"]
 {{- end }}

--- a/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-controller.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: efs-csi-controller
+    name: {{ .Values.controller.serviceAccount.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-controller.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount.name }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-provisioner-role

--- a/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-node.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: efs-csi-node
+    name: {{ .Values.node.serviceAccount.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/clusterrolebinding-efs-node.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.node.serviceAccount.name }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: efs-csi-node

--- a/helm/aws-efs-csi-driver/templates/controller-vpa.yaml
+++ b/helm/aws-efs-csi-driver/templates/controller-vpa.yaml
@@ -5,7 +5,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: efs-csi-controller
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/aws-efs-csi-driver/templates/controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/controller.yaml
@@ -25,10 +25,6 @@ spec:
         {{- with .Values.controller.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      securityContext:
-        fsGroup: 0
-        runAsGroup: 0
-        runAsUser: 0
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       priorityClassName: system-cluster-critical
       {{- with .Values.controller.tolerations }}

--- a/helm/aws-efs-csi-driver/templates/controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/controller.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: efs-csi-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app: efs-csi-controller
+        {{- include "labels.common" . | nindent 8 }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}

--- a/helm/aws-efs-csi-driver/templates/controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/controller.yaml
@@ -4,7 +4,6 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: efs-csi-controller
-  namespace: kube-system
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -16,55 +15,53 @@ spec:
     metadata:
       labels:
         app: efs-csi-controller
-        {{- include "labels.common" . | nindent 8 }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      hostNetwork: {{ .Values.controller.hostNetwork }}
+      hostNetwork: true
       nodeSelector:
-{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
+        kubernetes.io/os: linux
         {{- with .Values.controller.nodeSelector }}
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- else }}
-        kubernetes.io/role: master
-{{- end }}
       securityContext:
         fsGroup: 0
         runAsGroup: 0
         runAsUser: 0
-      serviceAccountName: efs-csi-controller
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       priorityClassName: system-cluster-critical
-      tolerations:
-        - operator: Exists
-        {{- with .Values.tolerations }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: efs-plugin
           securityContext:
             privileged: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v={{ .Values.logLevel }}
             {{- if .Values.controller.tags }}
             - --tags={{ include "aws-efs-csi-driver.tags" .Values.controller.tags }}
             {{- end }}
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.controller.logLevel }}
             - --delete-access-point-root-dir={{ hasKey .Values.controller "deleteAccessPointRootDir" | ternary .Values.controller.deleteAccessPointRootDir false }}
+            - --vol-metrics-opt-in={{ hasKey .Values.controller "volMetricsOptIn" | ternary .Values.controller.volMetricsOptIn false }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            {{- if .Values.controller.regionalStsEndpoints }}
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+            {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - name: healthz
-              containerPort: 9808
+              containerPort: {{ .Values.controller.healthPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -74,13 +71,19 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          {{- with .Values.controller.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.csiProvisioner.image.repository .Values.sidecars.csiProvisioner.image.tag }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v=5
+            - --v={{ .Values.controller.logLevel }}
             - --feature-gates=Topology=true
-            - --leader-election=true
+            {{- if .Values.controller.extraCreateMetadata }}
+            - --extra-create-metadata
+            {{- end }}
+            - --leader-election
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -88,14 +91,20 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           args:
             - --csi-address=/csi/csi.sock
-            - --health-port=9808
+            - --health-port={{ .Values.controller.healthPort }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/aws-efs-csi-driver/templates/networkpolicy-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/networkpolicy-csi-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: aws-efs-csi-controller
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 spec:
   egress:
   - {}

--- a/helm/aws-efs-csi-driver/templates/node-vpa.yaml
+++ b/helm/aws-efs-csi-driver/templates/node-vpa.yaml
@@ -4,7 +4,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: efs-csi-node
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/aws-efs-csi-driver/templates/node.yaml
+++ b/helm/aws-efs-csi-driver/templates/node.yaml
@@ -3,7 +3,6 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: efs-csi-node
-  namespace: kube-system
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -14,14 +13,13 @@ spec:
     metadata:
       labels:
         app: efs-csi-node
-        {{- include "labels.common" . | nindent 8 }}
       {{- if .Values.node.podAnnotations }}
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-    {{- if .Values.hostAliases }}
+    {{- with .Values.node.hostAliases }}
       hostAliases:
-      {{- range $k, $v := .Values.hostAliases }}
+      {{- range $k, $v := . }}
         - ip: {{ $v.ip }}
           hostnames:
             - {{ $k }}.efs.{{ $v.region }}.amazonaws.com
@@ -34,37 +32,20 @@ spec:
       {{- end }}
     {{- end }}
       nodeSelector:
-{{- if gt (len (keys .Values.node.nodeSelector)) 0 }}
+        beta.kubernetes.io/os: linux
         {{- with .Values.node.nodeSelector }}
-{{ toYaml . | indent 8 }}
-        {{- end }}
-{{- else }}
-        kubernetes.io/role: worker
-{{- end }}
-      hostNetwork: true
-      tolerations:
-        {{- if .Values.node.tolerateAllTaints }}
-        - operator: Exists
-        {{- else }}
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
-        {{- end }}
-      serviceAccountName: efs-csi-node
-      securityContext:
-        fsGroup: 0
-        runAsGroup: 0
-        runAsUser: 0
-      {{- if .Values.dnsPolicy }}
-      dnsPolicy: "{{ .Values.dnsPolicy }}"
-      {{- end }}
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
+      {{- with .Values.node.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: system-node-critical
+      {{- with .Values.node.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: efs-plugin
           securityContext:
@@ -73,7 +54,7 @@ spec:
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.node.logLevel }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -91,7 +72,7 @@ spec:
               mountPath: /etc/amazon/efs-legacy
           ports:
             - name: healthz
-              containerPort: 9809
+              containerPort: {{ .Values.node.healthPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -101,12 +82,15 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 2
             failureThreshold: 5
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: node-driver-registrar
-          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v={{ .Values.logLevel }}
+            - --v={{ .Values.node.logLevel }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -121,15 +105,21 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           args:
             - --csi-address=/csi/csi.sock
-            - --health-port=9809
-            - --v={{ .Values.logLevel }}
+            - --health-port={{ .Values.node.healthPort }}
+            - --v={{ .Values.node.logLevel }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          {{- with .Values.sidecars.livenessProbe.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/helm/aws-efs-csi-driver/templates/node.yaml
+++ b/helm/aws-efs-csi-driver/templates/node.yaml
@@ -3,6 +3,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: efs-csi-node
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/aws-efs-csi-driver/templates/psp-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/psp-csi-controller.yaml
@@ -14,8 +14,8 @@ spec:
   privileged: true
   hostNetwork: true
   hostPorts:
-  - max: 9808
-    min: 9808
+  - min: 9000
+    max: 10000
   supplementalGroups:
     ranges:
     - max: 65535

--- a/helm/aws-efs-csi-driver/templates/psp-csi-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/psp-csi-node.yaml
@@ -18,8 +18,8 @@ spec:
     rule: MustRunAs
   hostNetwork: true
   hostPorts:
-  - min: 9809
-    max: 9809
+  - min: 9000
+    max: 10000
   volumes:
   - secret
   - configMap

--- a/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -2,11 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-controller
-  namespace: kube-system
+  name: {{ .Values.controller.serviceAccount.name }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  {{- with .Values.serviceAccount.controller.annotations }}
+  {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.controller.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
   {{- with .Values.controller.serviceAccount.annotations }}

--- a/helm/aws-efs-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.node.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
   {{- with .Values.node.serviceAccount.annotations }}

--- a/helm/aws-efs-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-node
-  namespace: kube-system
+  name: {{ .Values.node.serviceAccount.name }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  {{- with .Values.serviceAccount.controller.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- with .Values.node.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -52,7 +52,8 @@ node:
   podAnnotations: {}
   resources:
     {}
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/role: worker
   tolerations:
     - operator: Exists
   # Specifies whether a service account should be created

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -54,8 +54,7 @@ node:
     {}
   nodeSelector:
     kubernetes.io/role: worker
-  tolerations:
-    - operator: Exists
+  tolerations: {}
   # Specifies whether a service account should be created
   serviceAccount:
     create: true

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -86,7 +86,8 @@ controller:
     {}
   nodeSelector:
     kubernetes.io/role: master
-  tolerations: []
+  tolerations:
+    - operator: Exists
   affinity: {}
   serviceAccount:
     create: true

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -13,80 +13,65 @@ image:
   pullPolicy: IfNotPresent
 
 sidecars:
-  livenessProbeImage:
-    repository: docker.io/giantswarm/livenessprobe
-    tag: "v2.6.0"
-  nodeDriverRegistrarImage:
-    repository: docker.io/giantswarm/csi-node-driver-registrar
-    tag: "v2.5.0"
-  csiProvisionerImage:
-    repository: docker.io/giantswarm/csi-provisioner
-    tag: "v3.1.0"
+  livenessProbe:
+    image:
+      repository: docker.io/giantswarm/livenessprobe
+      tag: "v2.7.0"
+    resources: {}
+  nodeDriverRegistrar:
+    image:
+      repository: docker.io/giantswarm/csi-node-driver-registrar
+      tag: "v2.5.1"
+    resources: {}
+  csiProvisioner:
+    image:
+      repository: docker.io/giantswarm/csi-provisioner
+      tag: "v3.1.0"
+    resources: {}
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-podAnnotations: {}
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 node:
-  nodeSelector: {}
-  tolerateAllTaints: true
+  # Number for the log level verbosity
+  logLevel: 2
+  hostAliases:
+    {}
+    # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
+    # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
+    # implementing the suggested solution found here:
+    # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
+    # EFS Vol ID, IP, Region
+    # "fs-01234567":
+    #   ip: 10.10.2.2
+    #   region: us-east-2
+  dnsPolicy: ClusterFirst
+  dnsConfig:
+    {}
   podAnnotations: {}
-  tolerations: []
-
-logLevel: 2
-
-hostAliases:
-  {}
-  # for cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
-  # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
-  # implementing the suggested solution found here:
-  # https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240#issuecomment-676849346
-  # EFS Vol ID, IP, Region
-  # "fs-01234567":
-  #   ip: 10.10.2.2
-  #   region: us-east-2
-
-dnsPolicy: ""
-dnsConfig:
-  {}
-  # Example config which uses the AWS nameservers
-  # dnsPolicy: "None"
-  # dnsConfig:
-  #   nameservers:
-  #     - 169.254.169.253
-
-serviceAccount:
-  controller:
-    # Specifies whether a service account should be created
+  resources:
+    {}
+  nodeSelector:
+    kubernetes.io/role: worker
+  tolerations:
+    - operator: Exists
+  # Specifies whether a service account should be created
+  serviceAccount:
+    create: true
+    name: efs-csi-node-sa
     annotations: {}
-    ## Enable if IAM roles for SA is used
+    ## Enable if EKS IAM for SA is used
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
-    name: efs-csi-controller
+  healthPort: 9809
 
 controller:
-  hostNetwork: true
-  create: false
-  nodeSelector: {}
+  # Specifies whether a deployment should be created
+  create: true
+  # Number for the log level verbosity
+  logLevel: 2
+  # If set, add pv/pvc metadata to plugin create requests as parameters.
+  extraCreateMetadata: true
   # Add additional tags to access points
   tags:
     {}
@@ -95,6 +80,22 @@ controller:
   # Enable if you want the controller to also delete the
   # path on efs when deleteing an access point
   deleteAccessPointRootDir: false
+  volMetricsOptIn: false
+  podAnnotations: {}
+  resources:
+    {}
+  nodeSelector:
+    kubernetes.io/role: master
+  tolerations: []
+  affinity: {}
+  serviceAccount:
+    create: true
+    name: efs-csi-controller-sa
+    annotations: {}
+    ## Enable if EKS IAM for SA is used
+    #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
+  healthPort: 9909
+  regionalStsEndpoints: false
 
 storageClasses: []
 # Add StorageClass resources like:

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -52,9 +52,9 @@ node:
   podAnnotations: {}
   resources:
     {}
-  nodeSelector:
-    kubernetes.io/role: worker
-  tolerations: {}
+  nodeSelector: {}
+  tolerations:
+    - operator: Exists
   # Specifies whether a service account should be created
   serviceAccount:
     create: true


### PR DESCRIPTION
- Use different ports to avoid collision with ebs controller using ports 9909 and 9809
- Updated chart to upstream 2.2.6
- Improve tolerations to deploy in all worker nodes
- Remove root security context from pods