### PR TITLE
fixed service account conditional creation for controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect the `controller.serviceAccount.create` values flag
+
+### Added
+
+- values.schema.json
+
 ## [0.6.0] - 2022-06-15
 
 ### Changed

--- a/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.controller.create }}
+{{- if .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/aws-efs-csi-driver/values.schema.json
+++ b/helm/aws-efs-csi-driver/values.schema.json
@@ -1,0 +1,238 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "controller": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "deleteAccessPointRootDir": {
+                    "type": "boolean"
+                },
+                "extraCreateMetadata": {
+                    "type": "boolean"
+                },
+                "healthPort": {
+                    "type": "integer"
+                },
+                "logLevel": {
+                    "type": "integer"
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/role": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "regionalStsEndpoints": {
+                    "type": "boolean"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tags": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "volMetricsOptIn": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "node": {
+            "type": "object",
+            "properties": {
+                "dnsConfig": {
+                    "type": "object"
+                },
+                "dnsPolicy": {
+                    "type": "string"
+                },
+                "healthPort": {
+                    "type": "integer"
+                },
+                "hostAliases": {
+                    "type": "object"
+                },
+                "logLevel": {
+                    "type": "integer"
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "kubernetes.io/role": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "sidecars": {
+            "type": "object",
+            "properties": {
+                "csiProvisioner": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "nodeDriverRegistrar": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "storageClasses": {
+            "type": "array"
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
to allow users to provide there own service account, for example for creating the service account with terraform where the eks.amazonaws.com/role-arn is known, the ServiceAccount needs to contain the if check for .Values.controller.serviceAccount.create.

Because in the values.yaml the variable controller.serviceAccount.create is already provided, this was intended.