### PR TITLE
Added projected to the list of permitted volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# Ignore all log files
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.6.2] - 2022-07-25
+
+### Fixed
+
 - Added `projected` to the list of permitted volumes in the `psp-csi-controller`.
 
 ## [0.6.1] - 2022-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2022-07-25
+- Added `projected` to the list of permitted volumes in the `psp-csi-controller`.
+
 ## [0.6.1] - 2022-07-19
 
 ### Fixed

--- a/helm/aws-efs-csi-driver/templates/psp-csi-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/psp-csi-controller.yaml
@@ -25,4 +25,5 @@ spec:
   - secret
   - configMap
   - emptyDir
+  - projected
 {{- end }}


### PR DESCRIPTION
If the `projected` volume is not in the list of allowed volumes in the `psp-csi-controller` then the controller deployment does not get scheduled.  
This happens when KIAM/IRSA is enabled before deploying the aws-efs-csi-driver app.  
If the `projected` volume is not enabled then the deployment returns a very generic admission error.