### PR TITLE
Added possibility to override deployment strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.2] - 2022-07-26
+## [0.6.3] - 2022-07-26
+
+### Fixed
+
+- Added the possibility to override the deployment strategy for the controller
 
 ## [0.6.2] - 2022-07-25
 

--- a/helm/aws-efs-csi-driver/templates/controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/controller.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.controller.strategy }}
+  strategy:
+    type: {{ .Values.controller.strategy }}
+  {{- end }}
   selector:
     matchLabels:
       app: efs-csi-controller

--- a/helm/aws-efs-csi-driver/values.schema.json
+++ b/helm/aws-efs-csi-driver/values.schema.json
@@ -117,6 +117,9 @@
                 "logLevel": {
                     "type": "integer"
                 },
+                "strategy": {
+                    "type": "string"
+                },
                 "nodeSelector": {
                     "type": "object",
                     "properties": {
@@ -160,7 +163,7 @@
         },
         "replicaCount": {
             "type": "integer"
-        },
+        },        
         "sidecars": {
             "type": "object",
             "properties": {

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -96,6 +96,9 @@ controller:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/efs-csi-role
   healthPort: 9909
   regionalStsEndpoints: false
+  # Specified the deployment strategy
+  # Ex: Recreate
+  strategy: RollingUpdate
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
Allow to set the deployment strategy to `Recreate` in the `values.yaml` so that the deployment can kill the existing pods which might be using already the hostPort, before upgrading to a newer version