### PR TITLE
Default deploymet strategy set to Recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.3] - 2022-07-26
+## [0.6.4] - 2022-07-26
+
+- Defaulting deployment strategy to `Recreate` for the controller
+
+### Fixed
 
 ## [0.6.3] - 2022-07-26
 

--- a/helm/aws-efs-csi-driver/values.schema.json
+++ b/helm/aws-efs-csi-driver/values.schema.json
@@ -163,7 +163,7 @@
         },
         "replicaCount": {
             "type": "integer"
-        },        
+        },
         "sidecars": {
             "type": "object",
             "properties": {

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -97,8 +97,8 @@ controller:
   healthPort: 9909
   regionalStsEndpoints: false
   # Specified the deployment strategy
-  # Ex: Recreate
-  strategy: RollingUpdate
+  # Ex: RollingUpdate
+  strategy: Recreate
 
 storageClasses: []
 # Add StorageClass resources like:


### PR DESCRIPTION
Recreate kills existing pods freeing up the used hostPort in the node