### PR TITLE
Fix csi-node PSP for IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `projected` volume type to csi-node PSP to allow the user of IRSA.
+
 ## [0.7.1] - 2022-11-15
 
 **WARNING** Please ensure you're running `kiam-app` with App Version `v2.5.1` or higher.

--- a/helm/aws-efs-csi-driver/templates/psp-csi-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/psp-csi-node.yaml
@@ -20,3 +20,4 @@ spec:
   - secret
   - configMap
   - hostPath
+  - projected


### PR DESCRIPTION
If using IRSA a `projected` volume is added to the pod with the IAM token. The PSP needs updating to allow it.