### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.2.0] - 2023-11-22
 
 ⚠️ Attention: Minor release [1.2.0] contains breaking changes in default user values! The name of the service account changed to `efs-csi-sa` for both components. This affects clusters with already configured IRSA roles. You either need to update the trust identity policy on the role to match the new service account or set service account names to the original values via the values file. ⚠️
@@ -72,8 +76,6 @@ You can verify this by describing `kiam-agent` DaemonSet and checking if `--allo
 
 - Update aws-efs-csi-driver version to `v1.4.4`.
 - Disable `hostNetwork`.
-
-## [0.6.4] - 2022-07-26
 
 ## [0.6.4] - 2022-07-26
 

--- a/helm/aws-efs-csi-driver/values.yaml
+++ b/helm/aws-efs-csi-driver/values.yaml
@@ -8,7 +8,7 @@ namespace: kube-system
 replicaCount: 1
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   repository: giantswarm/aws-efs-csi-driver
   tag: "v1.7.2"
   pullPolicy: IfNotPresent
@@ -36,8 +36,7 @@ fullnameOverride: ""
 node:
   # Number for the log level verbosity
   logLevel: 2
-  hostAliases:
-    {}
+  hostAliases: {}
     # For cross VPC EFS, you need to poison or overwrite the DNS for the efs volume as per
     # https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html#wt6-efs-utils-step3
     # implementing the suggested solution found here:
@@ -47,11 +46,9 @@ node:
     #   ip: 10.10.2.2
     #   region: us-east-2
   dnsPolicy: ClusterFirst
-  dnsConfig:
-    {}
+  dnsConfig: {}
   podAnnotations: {}
-  resources:
-    {}
+  resources: {}
   nodeSelector:
     node.kubernetes.io/worker: ""
   tolerations:
@@ -73,8 +70,7 @@ controller:
   # If set, add pv/pvc metadata to plugin create requests as parameters.
   extraCreateMetadata: true
   # Add additional tags to access points
-  tags:
-    {}
+  tags: {}
     # environment: prod
     # region: us-east-1
   # Enable if you want the controller to also delete the
@@ -82,8 +78,7 @@ controller:
   deleteAccessPointRootDir: false
   volMetricsOptIn: false
   podAnnotations: {}
-  resources:
-    {}
+  resources: {}
   nodeSelector:
     node-role.kubernetes.io/control-plane: ""
   tolerations:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
