### PR TITLE
Add even more PSS exceptions to make `node` component run on 1.25.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add even more PSS exceptions to make `node` component run on 1.25.
+
 ## [1.2.3] - 2024-01-16
 
 ### Fixed

--- a/helm/aws-efs-csi-driver/templates/pss-exceptions-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/pss-exceptions-node.yaml
@@ -43,9 +43,11 @@ spec:
     - policyName: disallow-host-namespaces
       ruleNames:
         - autogen-host-namespaces
+        - host-namespaces
     - policyName: disallow-host-ports
       ruleNames:
         - autogen-host-ports-none
+        - host-ports-none
   match:
     any:
       - resources:


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/29774

fix PSS