### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/aws-efs-csi-driver/templates/pss-exceptions-controller.yaml
+++ b/helm/aws-efs-csi-driver/templates/pss-exceptions-controller.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.podSecurityStandards.enforced }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: efs-csi-controller-exceptions

--- a/helm/aws-efs-csi-driver/templates/pss-exceptions-node.yaml
+++ b/helm/aws-efs-csi-driver/templates/pss-exceptions-node.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.podSecurityStandards.enforced }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: efs-csi-node-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.