### PR TITLE
Chart: Fix templating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Fix templating.
+
 ## [2.1.2] - 2025-09-11
 
 ### Changed

--- a/helm/aws-efs-csi-driver/templates/storageclass.yaml
+++ b/helm/aws-efs-csi-driver/templates/storageclass.yaml
@@ -4,7 +4,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "aws-efs-csi-driver.labels" . | nindent 4 }}
+    {{- include "aws-efs-csi-driver.labels" $ | nindent 4 }}
   {{- with .annotations }}
   annotations:
   {{ toYaml . | indent 4 }}


### PR DESCRIPTION
Otherwise I'm getting this error:

```
'template: aws-efs-csi-driver/templates/storageclass.yaml:7:8: executing
      "aws-efs-csi-driver/templates/storageclass.yaml" at <include "aws-efs-csi-driver.labels"
      .>: error calling include: template: aws-efs-csi-driver/templates/_helpers.tpl:38:27:
      executing "aws-efs-csi-driver.labels" at <include "aws-efs-csi-driver.name"
      .>: error calling include: template: aws-efs-csi-driver/templates/_helpers.tpl:6:18:
      executing "aws-efs-csi-driver.name" at <.Chart.Name>: nil pointer evaluating
      interface {}.Name'
```

I wonder how you couldn't spot this while changing stuff in this app lately, @paurosello @fiunchinho. 😅