### PR TITLE
Add CI helm values file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CI helm values file to check Helm rendering during CI.
+
 ## [2.1.3] - 2025-09-17
 
 ### Changed

--- a/helm/aws-efs-csi-driver/ci/test-storageclasses-values.yaml
+++ b/helm/aws-efs-csi-driver/ci/test-storageclasses-values.yaml
@@ -1,0 +1,17 @@
+storageClasses:
+- name: efs-default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  mountOptions:
+  - tls
+  parameters:
+    provisioningMode: efs-ap
+    fileSystemId: fs-1122aabb
+    directoryPerms: "700"
+    gidRangeStart: "1000"
+    gidRangeEnd: "2000"
+    basePath: "/dynamic_provisioning"
+    subPathPattern: "/subPath"
+    ensureUniqueDirectory: true
+  reclaimPolicy: Delete
+  volumeBindingMode: Immediate


### PR DESCRIPTION
We missed some bad templating on previous PR. We can run some checks in CI to catch those mistakes earlier.

I tested this by reverting the fix in the templates, and indeed CI failed because of it https://app.circleci.com/pipelines/github/giantswarm/aws-efs-csi-driver/1031/workflows/fab4e61d-334c-44d5-a46c-0da7cb11a1f3/jobs/992

So we are good.