### PR TITLE
Use .Chart.AppVersion instead of .Chart.Version

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,4 +1,5 @@
 chart-dir: helm/aws-efs-csi-driver
 replace-chart-version-with-git: true
+replace-app-version-with-git: true
 generate-metadata: true
 catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update ABS config to replace `.appVersion` in Chart.yaml with version detected by ABS.
+
+### Fixed
+
+- Use `.Chart.AppVersion` instead of `.Chart.Version` for OCIRepository tag.
+
 ## [3.2.0] - 2026-02-04
 
 ### Changed

--- a/helm/aws-efs-csi-driver-bundle/templates/_helpers.tpl
+++ b/helm/aws-efs-csi-driver-bundle/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "aws-efs-csi-driver-bundle.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/aws-efs-csi-driver-bundle/templates/helmreleases.yaml
+++ b/helm/aws-efs-csi-driver-bundle/templates/helmreleases.yaml
@@ -9,7 +9,7 @@ spec:
   url: {{ .Values.ociRepositoryUrl }}
   interval: 1h # Our versions are immutable, so there's no need to check for updates.
   ref:
-    tag: {{ .Chart.Version }}
+    tag: {{ .Chart.AppVersion }}
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/helm/aws-efs-csi-driver/templates/_helpers.tpl
+++ b/helm/aws-efs-csi-driver/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "aws-efs-csi-driver.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## Summary

- Use `.Chart.AppVersion` instead of `.Chart.Version` for the OCIRepository tag
- The chart version can contain build metadata (e.g., `+1234567`) which OCI registries don't support in tags

Towards https://github.com/giantswarm/roadmap/issues/4194